### PR TITLE
decrease-max-fix

### DIFF
--- a/lib/semaphore.ex
+++ b/lib/semaphore.ex
@@ -20,12 +20,31 @@ defmodule Semaphore do
 
   @doc """
   Acquire a semaphore, incrementing the internal count by one.
+
+  The semaphore's `name` can be any Elixir value.  The `max` count for the semaphore is passed on
+  every `acquire` call.  If the `max` is increased, the semaphore's count is preserved.  If the
+  `max` is decreased to a value lower than the current count, the count will be set to the new
+  `max`.
+
+  ## Example:
+
+      iex> Semaphore.acquire(:sem, 2)
+      true
+      iex> Semaphore.acquire(:sem, 2)
+      true
+      iex> Semaphore.acquire(:sem, 2)
+      false
+      iex> Semaphore.acquire(:sem, 3)
+      true
+      iex> Semaphore.acquire(:sem, 1)
+      false
+      iex> Semaphore.count(:sem)
+      1
   """
   @spec acquire(term, integer) :: boolean
   def acquire(name, max) do
     case ETS.update_counter(@table, name, [{2, 0}, {2, 1, max, max}], {name, 0}) do
-      [^max, _] -> false
-      _ -> true
+      [old_val, new_val] -> old_val < new_val
     end
   end
 

--- a/test/semaphore_test.exs
+++ b/test/semaphore_test.exs
@@ -1,5 +1,6 @@
 defmodule SemaphoreTest do
   use ExUnit.Case, async: false
+  doctest Semaphore
 
   setup do
     Semaphore.reset(:foo)
@@ -31,6 +32,13 @@ defmodule SemaphoreTest do
     assert Semaphore.acquire(:foo, 1) == true
     assert Semaphore.acquire(:foo, 3) == true
     assert Semaphore.acquire(:foo, 3) == true
+  end
+
+  test "decrease max" do
+    assert Semaphore.acquire(:foo, 2) == true
+    assert Semaphore.acquire(:foo, 2) == true
+    assert Semaphore.acquire(:foo, 2) == false
+    assert Semaphore.acquire(:foo, 1) == false
   end
 
   test "call" do


### PR DESCRIPTION
Fixes the behaviour of the `acquire/2` function when you provide a `max` which is less than the current count.

See the issue for more details: https://github.com/discord/semaphore/issues/6