### PR TITLE
Revise `call_linksafe/3` to keep track of multiple procs per semaphore

### DIFF
--- a/test/semaphore_test.exs
+++ b/test/semaphore_test.exs
@@ -41,17 +41,39 @@ defmodule SemaphoreTest do
   end
 
   test "call_linksafe" do
-    # Spawn a process that will exit due to a linked process exiting.
-    {pid, ref} = spawn_monitor(fn ->
+    # Assert similar behavior from call/3
+    assert Semaphore.call_linksafe(:foo, 5, fn -> :bar end) == :bar
+    assert Semaphore.count(:foo) == 0
+
+    # The call-safe table should be empty after a typical call to call_linksafe/3
+    assert :ets.lookup(:semaphore_call_safe, :foo) == []
+
+    assert Semaphore.acquire(:foo, 1) == true
+    assert Semaphore.call_linksafe(:foo, 1, fn -> :bar end) == {:error, :max}
+
+    # Reset for the following additional tests
+    Semaphore.reset(:foo)
+
+    # Spawn a couple processes that will exit due to a linked process exiting.
+    {pid1, ref1} = spawn_monitor(fn ->
       Semaphore.call_linksafe(:foo, 5, fn ->
         spawn_link(fn -> exit(:ded) end)
         Process.sleep(:infinity)
       end)
     end)
+
+    {pid2, ref2} = spawn_monitor(fn ->
+      Semaphore.call_linksafe(:foo, 5, fn ->
+        spawn_link(fn -> exit(:ded) end)
+        Process.sleep(:infinity)
+      end)
+    end)
+
     # Wait for the process to die.
-    assert_receive {:DOWN, ^ref, :process, ^pid, :ded}
+    assert_receive {:DOWN, ^ref1, :process, ^pid1, :ded}
+    assert_receive {:DOWN, ^ref2, :process, ^pid2, :ded}
     # The leak should have occurred.
-    assert Semaphore.count(:foo) == 1
+    assert Semaphore.count(:foo) == 2
     # Force a sweep.
     Semaphore |> send(:timeout)
     # This is just so that we can ensure the sweep was processed.


### PR DESCRIPTION
Before, `call_linksafe/3` used an ETS set to store a single PID per semaphore key, which does not allow for appropriate sweeping when a semaphore is acquired by more than one process at once.

The linksafe table has been changed to an ETS bag (multiple unique PIDs per semaphore key), along with appropriate related changes. The function test has also been extended to ensure correct behavior in the normal case, as well as when multiple dead procs require sweeping.