### PR TITLE
rudimentary acquire_linksafe, release_linksafe.

### DIFF
--- a/lib/semaphore.ex
+++ b/lib/semaphore.ex
@@ -46,9 +46,9 @@ defmodule Semaphore do
   `call_linksafe`, tThis function has higher overhead than `acquire/2`.
   """
   @spec acquire_linksafe(term, any, integer) :: boolean
-  def acquire_linksafe(name, semaphore_key, max) do
+  def acquire_linksafe(name, id, max) do
     if acquire(name, max) do
-      safe_key = {name, self(), semaphore_key}
+      safe_key = {name, self(), id}
 
       ETS.insert_new(@call_safe_table, [safe_key])
     else
@@ -63,8 +63,8 @@ defmodule Semaphore do
   `call_linksafe`, tThis function has higher overhead than `acquire/2`.
   """
   @spec release_linksafe(term, any) :: :ok
-  def release_linksafe(name, semaphore_key) do
-    safe_key = {name, self(), semaphore_key}
+  def release_linksafe(name, id) do
+    safe_key = {name, self(), id}
 
     release(name)
     ETS.delete(@call_safe_table, safe_key)
@@ -153,7 +153,7 @@ defmodule Semaphore do
 
   defp do_sweep() do
     ETS.foldl(
-      fn {name, pid, _key} = key, :ok ->
+      fn {name, pid, _id} = key, :ok ->
         with false <- Process.alive?(pid),
              1 <- :ets.select_delete(@call_safe_table, [{key, [], [true]}]) do
           release(name)

--- a/lib/semaphore.ex
+++ b/lib/semaphore.ex
@@ -50,7 +50,12 @@ defmodule Semaphore do
     if acquire(name, max) do
       safe_key = {name, self(), id}
 
-      ETS.insert_new(@call_safe_table, [safe_key])
+      if ETS.insert_new(@call_safe_table, [safe_key]) do
+        true
+      else
+        release(name)
+        false
+      end
     else
       false
     end

--- a/test/semaphore_test.exs
+++ b/test/semaphore_test.exs
@@ -63,14 +63,16 @@ defmodule SemaphoreTest do
   test "acquire_linksafe" do
     # Spawn a process that will exit due to a linked process exiting.
     {pid, ref} = spawn_monitor(fn ->
-      Semaphore.acquire_linksafe(:name, :key, 5)
+      max = 5
+      true = Semaphore.acquire_linksafe(:name, :key, max)
+      true = Semaphore.acquire_linksafe(:name, :key2, max)
       exit(:ded)
     end)
 
     # Wait for the process to die.
     assert_receive {:DOWN, ^ref, :process, ^pid, :ded}
     # The leak should have occurred.
-    assert Semaphore.count(:name) == 1
+    assert Semaphore.count(:name) == 2
     # Force a sweep.
     send(Semaphore, :timeout)
     # This is just so that we can ensure the sweep was processed.
@@ -83,7 +85,14 @@ defmodule SemaphoreTest do
     Semaphore.acquire_linksafe(:name, :key, 5)
     assert Semaphore.count(:name) == 1
 
+    Semaphore.acquire_linksafe(:name, :key2, 5)
+    assert Semaphore.count(:name) == 1
+
     Semaphore.release_linksafe(:name, :key)
+    assert Semaphore.count(:name) == 1
+
+
+    Semaphore.release_linksafe(:name, :key2)
     assert Semaphore.count(:name) == 0
   end
 end

--- a/test/semaphore_test.exs
+++ b/test/semaphore_test.exs
@@ -59,4 +59,31 @@ defmodule SemaphoreTest do
     # The leak should now be fixed.
     assert Semaphore.count(:foo) == 0
   end
+
+  test "acquire_linksafe" do
+    # Spawn a process that will exit due to a linked process exiting.
+    {pid, ref} = spawn_monitor(fn ->
+      Semaphore.acquire_linksafe(:name, :key, 5)
+      exit(:ded)
+    end)
+
+    # Wait for the process to die.
+    assert_receive {:DOWN, ^ref, :process, ^pid, :ded}
+    # The leak should have occurred.
+    assert Semaphore.count(:name) == 1
+    # Force a sweep.
+    send(Semaphore, :timeout)
+    # This is just so that we can ensure the sweep was processed.
+    :sys.get_state(Semaphore)
+    # The leak should now be fixed.
+    assert Semaphore.count(:name) == 0
+  end
+
+  test "release_linksafe" do
+    Semaphore.acquire_linksafe(:name, :key, 5)
+    assert Semaphore.count(:name) == 1
+
+    Semaphore.release_linksafe(:name, :key)
+    assert Semaphore.count(:name) == 0
+  end
 end

--- a/test/semaphore_test.exs
+++ b/test/semaphore_test.exs
@@ -42,12 +42,14 @@ defmodule SemaphoreTest do
 
   test "call_linksafe" do
     # Spawn a process that will exit due to a linked process exiting.
-    {pid, ref} = spawn_monitor(fn ->
-      Semaphore.call_linksafe(:foo, 5, fn ->
-        spawn_link(fn -> exit(:ded) end)
-        Process.sleep(:infinity)
+    {pid, ref} =
+      spawn_monitor(fn ->
+        Semaphore.call_linksafe(:foo, 5, fn ->
+          spawn_link(fn -> exit(:ded) end)
+          Process.sleep(:infinity)
+        end)
       end)
-    end)
+
     # Wait for the process to die.
     assert_receive {:DOWN, ^ref, :process, ^pid, :ded}
     # The leak should have occurred.
@@ -60,14 +62,59 @@ defmodule SemaphoreTest do
     assert Semaphore.count(:foo) == 0
   end
 
+  test "call_linksafe with full semaphore" do
+    # Assert similar behavior from call/3
+    assert Semaphore.call_linksafe(:foo, 5, fn -> :bar end) == :bar
+    assert Semaphore.count(:foo) == 0
+
+    # The call-safe table should be empty after a typical call to call_linksafe/3
+    assert :ets.lookup(:semaphore_call_safe, :foo) == []
+
+    assert Semaphore.acquire(:foo, 1) == true
+    assert Semaphore.call_linksafe(:foo, 1, fn -> :bar end) == {:error, :max}
+
+    # Reset for the following additional tests
+    Semaphore.reset(:foo)
+
+    # Spawn a couple processes that will exit due to a linked process exiting.
+    {pid1, ref1} =
+      spawn_monitor(fn ->
+        Semaphore.call_linksafe(:foo, 5, fn ->
+          spawn_link(fn -> exit(:ded) end)
+          Process.sleep(:infinity)
+        end)
+      end)
+
+    {pid2, ref2} =
+      spawn_monitor(fn ->
+        Semaphore.call_linksafe(:foo, 5, fn ->
+          spawn_link(fn -> exit(:ded) end)
+          Process.sleep(:infinity)
+        end)
+      end)
+
+    # Wait for the process to die.
+    assert_receive {:DOWN, ^ref1, :process, ^pid1, :ded}
+    assert_receive {:DOWN, ^ref2, :process, ^pid2, :ded}
+    # The leak should have occurred.
+    assert Semaphore.count(:foo) == 2
+    # Force a sweep.
+    Semaphore |> send(:timeout)
+    # This is just so that we can ensure the sweep was processed.
+    Semaphore |> :sys.get_state()
+    # The leak should now be fixed.
+    assert Semaphore.count(:foo) == 0
+  end
+
   test "acquire_linksafe" do
     # Spawn a process that will exit due to a linked process exiting.
-    {pid, ref} = spawn_monitor(fn ->
-      max = 5
-      true = Semaphore.acquire_linksafe(:name, :key, max)
-      true = Semaphore.acquire_linksafe(:name, :key2, max)
-      exit(:ded)
-    end)
+    {pid, ref} =
+      spawn_monitor(fn ->
+        max = 5
+        true = Semaphore.acquire_linksafe(:name, :key, max)
+        true = Semaphore.acquire_linksafe(:name, :key2, max)
+        exit(:ded)
+      end)
 
     # Wait for the process to die.
     assert_receive {:DOWN, ^ref, :process, ^pid, :ded}
@@ -86,11 +133,10 @@ defmodule SemaphoreTest do
     assert Semaphore.count(:name) == 1
 
     Semaphore.acquire_linksafe(:name, :key2, 5)
-    assert Semaphore.count(:name) == 1
+    assert Semaphore.count(:name) == 2
 
     Semaphore.release_linksafe(:name, :key)
     assert Semaphore.count(:name) == 1
-
 
     Semaphore.release_linksafe(:name, :key2)
     assert Semaphore.count(:name) == 0


### PR DESCRIPTION
rudimentary safe versions of acquire and release, such that the calling process' semaphore acquisitions get cleaned up upon an exit (unclean or otherwise).