### PR TITLE
feat: upgrade to elixir 1.18-otp-27

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 erl_crash.dump
 *.ez
 .DS_Store
+.expert/

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 28.0
+elixir 1.19-otp-28

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 28.0
-elixir 1.19-otp-28
+erlang 27.0
+elixir 1.18-otp-27

--- a/lib/semaphore.ex
+++ b/lib/semaphore.ex
@@ -8,11 +8,13 @@ defmodule Semaphore do
   use GenServer
 
   def start(_type, _args) do
-    import Supervisor.Spec, warn: false
-    Supervisor.start_link([worker(__MODULE__, [])], strategy: :one_for_one)
+    children = [
+      {__MODULE__, []}
+    ]
+    Supervisor.start_link(children, strategy: :one_for_one)
   end
 
-  def start_link() do
+  def start_link(_opts) do
     sweep_interval = Application.get_env(:semaphore, :sweep_interval, 5_000)
     GenServer.start_link(__MODULE__, sweep_interval, name: __MODULE__)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Semaphore.Mixfile do
     [
       app: :semaphore,
       version: "1.3.0",
-      elixir: "~> 1.3",
+      elixir: "~> 1.17",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       deps: deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Semaphore.Mixfile do
     [
       app: :semaphore,
       version: "1.3.0",
-      elixir: "~> 1.19",
+      elixir: "~> 1.18",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       deps: deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Semaphore.Mixfile do
     [
       app: :semaphore,
       version: "1.3.0",
-      elixir: "~> 1.17",
+      elixir: "~> 1.19",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       deps: deps(),


### PR DESCRIPTION
While using this library in an Elixir 1.18 project, I got the following warning:
<img width="1020" height="179" alt="image" src="https://github.com/user-attachments/assets/a3a1984d-4d65-43ae-86d0-10a739c98f79" />
